### PR TITLE
Generate migration files with datetime prefix, to avoid collision on …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ __pycache__/
 /build/
 /dist/
 venv/
-
+.vscode

--- a/cassandra_migrate/cli.py
+++ b/cassandra_migrate/cli.py
@@ -92,11 +92,12 @@ def main():
 
     if opts.action == 'generate':
         clean_desc = '_'.join(opts.description.split())
-        next_version = len(config.migrations) + 1
-        date = arrow.now().format()
+        now = arrow.now()
+        date = now.format()
+        prefix = now.format('YYYYMMDDHHmmss')
 
         new_path = os.path.join(config.migrations_path,
-            'v{:03d}_{}.cql'.format(next_version, clean_desc))
+            '{}_{}.cql'.format(prefix, clean_desc))
 
         with io.open(new_path, 'w', encoding='utf-8') as f:
             f.write(NEW_MIGRATION_TEXT.lstrip().format(


### PR DESCRIPTION
#3 …the version prefix.

Please test the modifications. I verified it in the REPL, but was not able to execute the CLI as a local development project, instead of the installed version of cassandra-migrate. (Python noob)