### PR TITLE
Update docstring for Migrator initialiser options

### DIFF
--- a/cassandra_migrate/migrator.py
+++ b/cassandra_migrate/migrator.py
@@ -83,7 +83,7 @@ def cassandra_ddl_repr(data):
 class Migrator(object):
     """Execute migration operations in a C* database based on configuration.
 
-    `opts` must contain at least the following attributes:
+    `config` must contain at least the following keys:
     - config_file: path to a YAML file containing the configuration
     - profiles: map of profile names to keyspace settings
     - user, password: authentication options. May be None to not use it.


### PR DESCRIPTION
The previous docstring was somewhat confusing: the parameter is called 'config', not 'opts' (the 'opts' name is what callers pass), and the word 'attributes' made it sound like 'opts' was supposed to be an object, rather than a mapping type.