### PR TITLE
Fix missing imports in migrator.py.

### DIFF
--- a/cassandra_migrate/__init__.py
+++ b/cassandra_migrate/__init__.py
@@ -41,7 +41,7 @@ class InconsistentState(MigrationError):
 
 class UnknownMigration(MigrationError):
     """Database contains migrations that have not been specified"""
-    def __init__(self, version):
+    def __init__(self, version, name):
         self.version = version
         self.migration_name = name
 

--- a/cassandra_migrate/migrator.py
+++ b/cassandra_migrate/migrator.py
@@ -8,16 +8,15 @@ import re
 import logging
 import uuid
 import codecs
-from collections import namedtuple
 from future.moves.itertools import zip_longest
 
 import arrow
 from tabulate import tabulate
-from cassandra import ConsistencyLevel, DriverException
+from cassandra import ConsistencyLevel
 from cassandra.cluster import Cluster
 from cassandra.auth import PlainTextAuthProvider
-from cassandra_migrate import (Migration, MigrationConfig, FailedMigration,
-                               InconsistentState)
+from cassandra_migrate import (Migration, FailedMigration, InconsistentState,
+                               UnknownMigration, ConcurrentMigration)
 from cassandra_migrate.cql import CqlSplitter
 
 


### PR DESCRIPTION
A couple of small fixes:

 - Add missing imports to migrator.py
- Remove some imports that weren't used (also in migrator.py).