### PR TITLE
Fix $$ string detection in cql tokenizer

### DIFF
--- a/cassandra_migrate/cql.py
+++ b/cassandra_migrate/cql.py
@@ -37,7 +37,7 @@ class CqlSplitter(object):
                 (r"\/\*.+?\*\/",               h(cls.BLOCK_COMMENT)),
                 (r'"(?:[^"\\]|\\.)*"',         h(cls.STRING)),
                 (r"'(?:[^'\\]|\\.)*'",         h(cls.STRING)),
-                (r"\$\$(?:[^\$\\]|\\.)*\$\$'", h(cls.STRING)),
+                (r"\$\$(?:[^\$\\]|\\.)*\$\$",  h(cls.STRING)),
                 (r";",                         h(cls.SEMICOLON)),
                 (r"\s+",                       h(cls.WHITESPACE)),
                 (r".",                         h(cls.OTHER))

--- a/cassandra_migrate/test/test_cql.py
+++ b/cassandra_migrate/test/test_cql.py
@@ -30,7 +30,11 @@ from cassandra_migrate.cql import CqlSplitter
      CREATE TABLE 'hello;';
      CREATE TABLE "world;"
      ''',
-     ["CREATE TABLE 'hello;'", 'CREATE TABLE "world;"'])
+     ["CREATE TABLE 'hello;'", 'CREATE TABLE "world;"']),
+    # Double-dollar-sign quoted strings, as reported in PR #24
+    ('INSERT INTO test (test) VALUES '
+     '($$Pesky semicolon here ;Hello$$);',
+     ["INSERT INTO test (test) VALUES ($$Pesky semicolon here ;Hello$$)"])
 ])
 def test_cql_split(cql, statements):
     result = CqlSplitter.split(cql.strip())


### PR DESCRIPTION
I found this bug when the tool failed to apply a migration that had a user-defined function.