### PR TITLE
Support protocol v3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,6 +158,8 @@ Common parameters:
                         migrations are run against. This option must be used
                         in conjuction with the -k option. This option is
                         ignored unless the -s option is provided.
+  -v PROTOCOL_VERSION, --protocol-version PROTOCOL_VERSION
+                        Protocol version used to connect to Cassandra.
   -y, --assume-yes      Automatically answer "yes" for all questions
 
 migrate

--- a/cassandra_migrate/cli.py
+++ b/cassandra_migrate/cli.py
@@ -70,6 +70,8 @@ def main():
                         migrations are run against. This option must be used in
                         conjuction with the -k option. This option is ignored
                         unless the -s option is provided.""")
+    parser.add_argument('-v', '--protocol-version', type=int, default=None,
+                        help='Protocol version used to connect to Cassandra.')
     parser.add_argument('-y', '--assume-yes', action='store_true',
                         help='Automatically answer "yes" for all questions')
 
@@ -139,7 +141,8 @@ def main():
                       user=opts.user, password=opts.password,
                       host_cert_path=opts.ssl_cert,
                       client_key_path=opts.ssl_client_private_key,
-                      client_cert_path=opts.ssl_client_cert) as migrator:
+                      client_cert_path=opts.ssl_client_cert,
+                      protocol_version=opts.protocol_version) as migrator:
             cmd_method = getattr(migrator, opts.action)
             if not callable(cmd_method):
                 print('Error: invalid command', file=sys.stderr)

--- a/cassandra_migrate/migrator.py
+++ b/cassandra_migrate/migrator.py
@@ -116,7 +116,8 @@ class Migrator(object):
 
     def __init__(self, config, profile='dev', hosts=['127.0.0.1'], port=9042,
                  user=None, password=None, host_cert_path=None,
-                 client_key_path=None, client_cert_path=None):
+                 client_key_path=None, client_cert_path=None,
+                 protocol_version=None):
         self.config = config
 
         try:
@@ -137,14 +138,21 @@ class Migrator(object):
         else:
             ssl_options = None
 
-        self.cluster = Cluster(
-            contact_points=hosts,
-            port=port,
-            auth_provider=auth_provider,
-            max_schema_agreement_wait=300,
-            control_connection_timeout=10,
-            connect_timeout=30,
-            ssl_options=ssl_options)
+        cluster_kwargs = {
+            "contact_points": hosts,
+            "port": port,
+            "auth_provider": auth_provider,
+            "max_schema_agreement_wait": 300,
+            "control_connection_timeout": 10,
+            "connect_timeout": 30,
+            "ssl_options": ssl_options,
+        }
+        # Cluster defaults `protocol_version` to `cluster._NOT_SET`
+        # Only pass it to `Cluster` if it has been set, otherwise let it use
+        # its default
+        if protocol_version is not None:
+            cluster_kwargs["protocol_version"] = protocol_version
+        self.cluster = Cluster(**cluster_kwargs)
 
         self._session = None
 


### PR DESCRIPTION
Allow a Cassandra `protocol_version` to be passed in as an argument in the CLI and use that when creating a `Cluster`. If no protocol is passed in, the default, existing behaviour with continue to happen.

Also, replace `toTimestamp` with `dateof` when inserting the DB migration version fi the cluster is using protocol version 3, since `toTimestamp` was introduced in version 4