### PR TITLE
PyYAML vulnerability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ env:
   # cassandra-driver takes ages to install with Cython enabled
   - CASS_DRIVER_NO_CYTHON=1
 matrix:
-
   include:
     - python: "2.7"
-    - python: "3.4"
     - python: "3.5"
     - python: "3.6"
     - python: pypy3.5-5.8.0

--- a/cassandra_migrate/config.py
+++ b/cassandra_migrate/config.py
@@ -114,6 +114,6 @@ class MigrationConfig(object):
     def load(cls, path):
         """Load a migration config from a file, using it's dir. as base path"""
         with open(path, 'r', encoding='utf-8') as f:
-            config = yaml.load(f)
+            config = yaml.load(f, Loader=yaml.SafeLoader)
 
         return cls(config, os.path.dirname(path))

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='cassandra-migrate',
       install_requires=[
           'cassandra-driver',
           'future',
-          'PyYAML<5.0',
+          'PyYAML>=5.3.1',
           'arrow',
           'tabulate'
       ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py27
-    py34
     py35
     py36
     pypy3


### PR DESCRIPTION
Upgrading the version of PyYAML because it may cause a [vulnerability risk](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1747). This tool can then be used safely in an enterprise environment.



[Twine  ](https://github.com/Cobliteam/cassandra-migrate/blob/master/requirements-dev.txt#L6)does not support Python 3.4 anymore https://github.com/pypa/twine/commit/94b8cef2ca0b9b97af6a6521b18cc409426aafc9, so I also dropped the Python 3.4 support. 
