### PR TITLE
make pyyaml dependency less restrictive

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     "future==0.18.2",
     "geomet==0.2.1.post1",
     "python-dateutil==2.8.1",
-    "PyYAML==5.3.1",
+    "PyYAML==5.*",
     "six==1.15.0",
     "tabulate==0.8.9",
     "typing-extensions==3.7.4.3"]


### PR DESCRIPTION
with changes in pip 21 a new dependency resolver was introduced. We are now seeing issues like the following

The conflict is caused by:
cassandra-migrate 0.3.4 depends on PyYAML==5.3.1
pyaml-env 1.1.1 depends on PyYAML==5.4.1

this PR makes the dependency less restrictive and gives a chance to resolver to resolve dependency clash