### PR TITLE
allow customizing cluster options using an init file

### DIFF
--- a/cassandra_migrate/migrator.py
+++ b/cassandra_migrate/migrator.py
@@ -116,7 +116,8 @@ class Migrator(object):
 
     def __init__(self, config, profile='dev', hosts=['127.0.0.1'], port=9042,
                  user=None, password=None, host_cert_path=None,
-                 client_key_path=None, client_cert_path=None):
+                 client_key_path=None, client_cert_path=None,
+                 init_file=None):
         self.config = config
 
         try:
@@ -137,7 +138,8 @@ class Migrator(object):
         else:
             ssl_options = None
 
-        self.cluster = Cluster(
+        create_cluster = init_file.create_cluster if hasattr(init_file, 'create_cluster') else lambda **kwargs: Cluster(**kwargs)
+        self.cluster = create_cluster(
             contact_points=hosts,
             port=port,
             auth_provider=auth_provider,


### PR DESCRIPTION
Currently cassandra-migrate does not provide a way to customize cluster options, such as policies for load balancing, address translation (crucial when the cluster is in a private subnet and you need to map internal ips to external hostnames), etc.

This PR adds a way to override cluster options by defining an init file, e.g. cassandra-migrate.init.py, with contents like:

```python
from cassandra.cluster import Cluster
from cassandra.policies import WhiteListRoundRobinPolicy

def create_cluster(**kwargs):
  kwargs['load_balancing_policy'] = WhiteListRoundRobinPolicy(['127.0.0.1'])
  return Cluster(**kwargs)
```

I'd like to know if there is interest in merging this PR. If there is, I will add tests and documentation.
